### PR TITLE
Set lower bound of aeson to >=0.4

### DIFF
--- a/ekg-json.cabal
+++ b/ekg-json.cabal
@@ -20,7 +20,7 @@ library
   exposed-modules:
     System.Metrics.Json
   build-depends:
-    aeson < 0.12,
+    aeson >=0.4 && < 0.12,
     base >= 4.5 && < 4.10,
     ekg-core >= 0.1 && < 0.2,
     text < 1.3,


### PR DESCRIPTION
in [`aeson-0.3.*` `Object`](http://hackage.haskell.org/package/aeson-0.3.2.14/docs/Data-Aeson-Types.html#t:Object) is `Map` not `HashMap`

_NOTE_ cabal cannot find a build plan for `ekg-json` on GHC-7.4.2 anymore, because `ekg-core` wants `containers-0.5.x`, and then situation gets complicated.
