### PR TITLE
Make it build with ghc-9.10

### DIFF
--- a/ekg-json.cabal
+++ b/ekg-json.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:  System.Metrics.Json
   build-depends:
       aeson                 >=0.4 && <1.6  || >=2.0 && <2.3
-    , base                  >=4.6 && <4.20
+    , base                  >=4.6 && <4.21
     , ekg-core              >=0.1 && <0.2
     , text                  <2.2
     , unordered-containers  <0.3


### PR DESCRIPTION
All that was required was a bump to the `base` dependency.

This can be fixed on Hackage with a metadata edit. As a Haskell Trustee, I can do that for you if you would like.